### PR TITLE
Brew breaks when redefining common functions

### DIFF
--- a/R/brew.R
+++ b/R/brew.R
@@ -191,11 +191,10 @@ function(file=stdin(),output=stdout(),text=NULL,envir=parent.frame(),run=TRUE,pa
 			file.cache <- get(filekey,.cache)
 			file.mtime <- file.info(file)$mtime
 			if (file.cache$mtime >= file.mtime){
-				brew.cached <- .brew.cached
 				if (!missing(output)) {
-					return(brew.cached(output,envir))
+					return(.brew.cached(output,envir))
 				} else {
-					return(brew.cached(envir=envir))
+					return(.brew.cached(envir=envir))
 				}
 			}
 		}
@@ -347,7 +346,6 @@ function(file=stdin(),output=stdout(),text=NULL,envir=parent.frame(),run=TRUE,pa
 		brew.env <- new.env(parent=envir)
 		assign('text',text,brew.env)
 		assign('code',parse(text=code,srcfile=NULL),brew.env)
-		brew.cached <- .brew.cached
 
 		if (canCache){
 			if (file.mtime == FALSE) file.mtime <- file.info(file)$mtime
@@ -355,9 +353,9 @@ function(file=stdin(),output=stdout(),text=NULL,envir=parent.frame(),run=TRUE,pa
 		}
 
 		if (!missing(output)) {
-			return(brew.cached(output,brew.env))
+			return(.brew.cached(output,brew.env))
 		} else {
-			return(brew.cached(envir=brew.env))
+			return(.brew.cached(envir=brew.env))
 		}
 	} else if (parseCode){
 		brew.cached <- function (output=stdout(),parent.env=envir) {


### PR DESCRIPTION
Due to scoping, Brew breaks when the user has redefined any of several common functions. Our particular case occurs because we are redefining the [`<-` operator](https://gist.github.com/klmr/25dc765211c59bb749b0) but the problem will also occur for any other function that is used inside `.brew.cached`, because `.brew.cached` is injected into (a namespace inheriting from) the global namespace, rather than being executed in its proper package namespace.

Here’s an MWE to illustrate the problem:

``` r
library(brew)
# Redefine a function used in `.brew.cached`
exists = function (df, x) x %in% rownames(df)
brew(text = 'test')
# Error in exists(".brew.cat", envir = envir) :
#   unused argument (envir = envir)
```

The problem, as I’ve said, is that `.brew.cached` is injected into the user namespace, thus subverting the R package namespace mechanism, which is designed to avoid this kind of name clashes. Unfortunately, the nature of Brew doesn’t make it trivial to fix this.

The attached PR fixes this by undoing the environment injection, and instead using explicit environment accesses, where required.
